### PR TITLE
Fixed a non-deterministic test

### DIFF
--- a/src/main/java/translation/Database.java
+++ b/src/main/java/translation/Database.java
@@ -330,7 +330,7 @@ public class Database {
     public ArrayList<String> translateSentences(String sentence, String fromLanguage,
                                                 String toLanguage) throws NullPointerException {
         String []arrStr = sentence.split (" ");
-        HashMap<String, ArrayList<String>> synonyms = new HashMap<>();
+        HashMap<String, ArrayList<String>> synonyms = new LinkedHashMap<>();
         ArrayList<String>  sentences = new ArrayList<String>();
 
         for (String str:arrStr) {


### PR DESCRIPTION
### Issue: 
The testArrayOfSynonyms test in DatabaseTest.java fails due to an assertCheck between two ArrayLists

https://github.com/sabidea23/SmartTranslator/blob/531cfab7a693411d54d84514dcec3c4e79c0078b/src/test/java/DatabaseTest.java#L141

The reason behind this failure is because, the translateSentences() function in Database.java used HashMap to generate synonyms. According to the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), HashMap does not maintain the order in which the elements are inserted. This caused the test to fail as the orders of the two ArrayLists differ. 

### Fix:
Changing HashMap to LinkedHashMap will fix this non-determinism. According to the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html), LinkedHashMap maintains the order in which the elements are inserted. This way when we do the assert check, the order of the elements are maintained and thus the test passes. 

### Steps to reproduce the behavior:
I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation

**Clone the Repo**
```
https://github.com/sabidea23/SmartTranslator.git
```
**Compile the project**
```
mvn install -am -DskipTests
```
**(Optional) Run the unit test**
```
mvn test
```
**Run the unit test using NonDex**
```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex
```

### Stack trace for additional information:
```
testArrayOfSynonyms(DatabaseTest)  Time elapsed: 0.001 sec  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <[Cotoroabă inghiti , Cătușă hrani , Mâță mesteca ]> but was: <[Hrani cătușă , Inghiti cotoroabă , Mâță mesteca ]>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
        at DatabaseTest.testArrayOfSynonyms(DatabaseTest.java:144)
```